### PR TITLE
資本金と代表者名を変更する

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -20,5 +20,5 @@
     "**/node_modules": true,
     "**/yarn.lock": true
   },
-  "cSpell.words": ["Parens"]
+  "cSpell.words": ["Guildex", "Parens"]
 }

--- a/src/components/atoms/CompanyProfile/const.ts
+++ b/src/components/atoms/CompanyProfile/const.ts
@@ -15,7 +15,7 @@ export const COMPANY_DATA = [
   },
   {
     key: "資本金",
-    value: `${formatMoneyJapaneseYen(2100000)}円`,
+    value: `${formatMoneyJapaneseYen(3500000)}円`,
   },
   {
     key: "設立",
@@ -23,7 +23,7 @@ export const COMPANY_DATA = [
   },
   {
     key: "最高経営責任者",
-    value: "大橋 勇",
+    value: "木村一貴",
   },
   {
     key: "事業内容",


### PR DESCRIPTION
## やったこと

- 資本金 : 2100000 から 3500000
- 最高経営責任者 : 大橋勇 から 木村一貴